### PR TITLE
feat: Support Many To Many Association

### DIFF
--- a/lib/typed_ecto_schema/ecto_type_mapper.ex
+++ b/lib/typed_ecto_schema/ecto_type_mapper.ex
@@ -42,8 +42,8 @@ defmodule TypedEctoSchema.EctoTypeMapper do
     ecto_type
     |> base_type_for(opts)
     |> wrap_embeds_many(function_name)
-    |> add_nil_if_nullable(field_is_nullable?(nullable_default, function_name, opts))
     |> wrap_assoc_type(function_name)
+    |> add_nil_if_nullable(field_is_nullable?(nullable_default, function_name, opts))
   end
 
   # Gets the base type for a given Ecto.Type.t()

--- a/lib/typed_ecto_schema/syntax_sugar.ex
+++ b/lib/typed_ecto_schema/syntax_sugar.ex
@@ -13,7 +13,8 @@ defmodule TypedEctoSchema.SyntaxSugar do
     :embeds_many,
     :has_one,
     :has_many,
-    :belongs_to
+    :belongs_to,
+    :many_to_many
   ]
 
   @embeds_function_names [:embeds_one, :embeds_many]

--- a/lib/typed_ecto_schema/type_builder.ex
+++ b/lib/typed_ecto_schema/type_builder.ex
@@ -10,6 +10,7 @@ defmodule TypedEctoSchema.TypeBuilder do
           | :has_one
           | :has_many
           | :belongs_to
+          | :many_to_many
 
   @typep schema_option ::
            {:null, boolean()}

--- a/test/typed_ecto_schema_test.exs
+++ b/test/typed_ecto_schema_test.exs
@@ -37,6 +37,14 @@ defmodule TypedEctoSchemaTest do
     end
   end
 
+  defmodule ManyToMany do
+    use TypedEctoSchema
+
+    typed_schema "many_to_many" do
+      field(:int, :integer)
+    end
+  end
+
   {:module, _name, bytecode, _exports} =
     defmodule TestStruct do
       use TypedEctoSchema
@@ -57,6 +65,7 @@ defmodule TypedEctoSchemaTest do
         has_one(:has_one, HasOne)
         has_many(:has_many, HasMany)
         belongs_to(:belongs_to, BelongsTo)
+        many_to_many(:many_to_many, ManyToMany, join_through: "join_table")
         timestamps()
       end
 
@@ -218,6 +227,7 @@ defmodule TypedEctoSchemaTest do
           has_one(:has_one, HasOne)
           has_many(:has_many, HasMany)
           belongs_to(:belongs_to, BelongsTo)
+          many_to_many(:many_to_many, ManyToMany, join_through: "join_table")
           timestamps()
         end
 
@@ -236,12 +246,11 @@ defmodule TypedEctoSchemaTest do
                 enum_type_required: :foo1 | :foo2 | :foo3,
                 embed: Embedded.t() | nil,
                 embeds: list(Embedded.t()),
-                has_one: (HasOne.t() | unquote(NotLoaded).t()) | nil,
-                has_many: list(HasMany.t()) | unquote(NotLoaded).t(),
-                belongs_to:
-                  (BelongsTo.t() | unquote(NotLoaded).t())
-                  | nil,
+                has_one: unquote(Ecto.Schema).has_one(unquote(HasOne).t() | nil),
+                has_many: unquote(Ecto.Schema).has_many(unquote(HasMany).t()),
+                belongs_to: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil),
                 belongs_to_id: integer() | nil,
+                many_to_many: unquote(Ecto.Schema).many_to_many(unquote(ManyToMany).t()),
                 inserted_at: unquote(NaiveDateTime).t() | nil,
                 updated_at: unquote(NaiveDateTime).t() | nil
               }
@@ -303,14 +312,11 @@ defmodule TypedEctoSchemaTest do
           enum_type_required: :foo1 | :foo2 | :foo3,
           embed: unquote(Embedded).t() | nil,
           embeds: list(unquote(Embedded).t()),
-          has_one:
-            (unquote(HasOne).t() | unquote(NotLoaded).t())
-            | nil,
-          has_many: list(unquote(HasMany).t()) | unquote(NotLoaded).t(),
-          belongs_to:
-            (unquote(BelongsTo).t() | unquote(NotLoaded).t())
-            | nil,
+          has_one: unquote(Ecto.Schema).has_one(unquote(HasOne).t() | nil),
+          has_many: unquote(Ecto.Schema).has_many(unquote(HasMany).t()),
+          belongs_to: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil),
           belongs_to_id: integer() | nil,
+          many_to_many: unquote(Ecto.Schema).many_to_many(unquote(ManyToMany).t()),
           inserted_at: unquote(NaiveDateTime).t() | nil,
           updated_at: unquote(NaiveDateTime).t() | nil
         ]
@@ -329,12 +335,8 @@ defmodule TypedEctoSchemaTest do
           normal: integer(),
           enforced: integer(),
           overriden: integer() | nil,
-          has_one:
-            (unquote(HasOne).t() | unquote(NotLoaded).t())
-            | nil,
-          belongs_to:
-            (unquote(BelongsTo).t() | unquote(NotLoaded).t())
-            | nil,
+          has_one: unquote(Ecto.Schema).has_one(unquote(HasOne).t() | nil),
+          belongs_to: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil),
           belongs_to_id: integer()
         ]
       end
@@ -348,21 +350,13 @@ defmodule TypedEctoSchemaTest do
       quote do
         [
           __meta__: unquote(Metadata).t(),
-          normal:
-            (unquote(BelongsTo).t() | unquote(NotLoaded).t())
-            | nil,
+          normal: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil),
           normal_id: integer() | nil,
-          with_custom_fk:
-            (unquote(BelongsTo).t() | unquote(NotLoaded).t())
-            | nil,
+          with_custom_fk: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil),
           custom_fk: integer() | nil,
-          custom_type:
-            (unquote(BelongsTo).t() | unquote(NotLoaded).t())
-            | nil,
+          custom_type: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil),
           custom_type_id: binary() | nil,
-          no_define:
-            (unquote(BelongsTo).t() | unquote(NotLoaded).t())
-            | nil
+          no_define: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil)
         ]
       end
 

--- a/test/typed_ecto_schema_test.exs
+++ b/test/typed_ecto_schema_test.exs
@@ -246,9 +246,9 @@ defmodule TypedEctoSchemaTest do
                 enum_type_required: :foo1 | :foo2 | :foo3,
                 embed: Embedded.t() | nil,
                 embeds: list(Embedded.t()),
-                has_one: unquote(Ecto.Schema).has_one(unquote(HasOne).t() | nil),
+                has_one: unquote(Ecto.Schema).has_one(unquote(HasOne).t()) | nil,
                 has_many: unquote(Ecto.Schema).has_many(unquote(HasMany).t()),
-                belongs_to: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil),
+                belongs_to: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
                 belongs_to_id: integer() | nil,
                 many_to_many: unquote(Ecto.Schema).many_to_many(unquote(ManyToMany).t()),
                 inserted_at: unquote(NaiveDateTime).t() | nil,
@@ -312,9 +312,9 @@ defmodule TypedEctoSchemaTest do
           enum_type_required: :foo1 | :foo2 | :foo3,
           embed: unquote(Embedded).t() | nil,
           embeds: list(unquote(Embedded).t()),
-          has_one: unquote(Ecto.Schema).has_one(unquote(HasOne).t() | nil),
+          has_one: unquote(Ecto.Schema).has_one(unquote(HasOne).t()) | nil,
           has_many: unquote(Ecto.Schema).has_many(unquote(HasMany).t()),
-          belongs_to: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil),
+          belongs_to: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
           belongs_to_id: integer() | nil,
           many_to_many: unquote(Ecto.Schema).many_to_many(unquote(ManyToMany).t()),
           inserted_at: unquote(NaiveDateTime).t() | nil,
@@ -335,8 +335,8 @@ defmodule TypedEctoSchemaTest do
           normal: integer(),
           enforced: integer(),
           overriden: integer() | nil,
-          has_one: unquote(Ecto.Schema).has_one(unquote(HasOne).t() | nil),
-          belongs_to: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil),
+          has_one: unquote(Ecto.Schema).has_one(unquote(HasOne).t()) | nil,
+          belongs_to: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
           belongs_to_id: integer()
         ]
       end
@@ -350,13 +350,13 @@ defmodule TypedEctoSchemaTest do
       quote do
         [
           __meta__: unquote(Metadata).t(),
-          normal: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil),
+          normal: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
           normal_id: integer() | nil,
-          with_custom_fk: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil),
+          with_custom_fk: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
           custom_fk: integer() | nil,
-          custom_type: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil),
+          custom_type: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
           custom_type_id: binary() | nil,
-          no_define: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t() | nil)
+          no_define: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil
         ]
       end
 


### PR DESCRIPTION
This is my first attempt at adding support for `many_to_many` as requested in #5.

Since the last time I used, Ecto team added association types at `Ecto.Schema`, such as `Ecto.Schema.many_to_many(t)` and `Ecto.Schema.belongs_to(t)` which is basically `t | Ecto.Association.NotLoaded.t()` which we were already generating. However, by reusing the ecto provided types the resulting type will be much more readable so I changed the code to use those types as well.

I haven't tested thoroughly though. But I think this is probably enough.

I also did some refactoring to the code and because of that I'll wait for #8 to be merged because there will probably be some conflicts.