### PR TITLE
Support types represented with 'source override' tuples

### DIFF
--- a/lib/typed_ecto_schema/ecto_type_mapper.ex
+++ b/lib/typed_ecto_schema/ecto_type_mapper.ex
@@ -47,7 +47,11 @@ defmodule TypedEctoSchema.EctoTypeMapper do
   end
 
   # Gets the base type for a given Ecto.Type.t()
-  @spec base_type_for(Ecto.Type.t(), field_options()) :: Macro.t()
+  @spec base_type_for(Ecto.Type.t() | {String.t(), Ecto.Type.t()}, field_options()) :: Macro.t()
+  defp base_type_for({source, actual_type}, opts) when is_binary(source) do
+    base_type_for(actual_type, opts)
+  end
+
   defp base_type_for(atom, _opts) when atom in @module_for_ecto_type_keys do
     quote do
       unquote(Map.get(@module_for_ecto_type, atom)).t()

--- a/test/typed_ecto_schema_test.exs
+++ b/test/typed_ecto_schema_test.exs
@@ -617,6 +617,29 @@ defmodule TypedEctoSchemaTest do
              delete_context(embed_types)
   end
 
+  defmodule RelationWithCustomSource do
+    use TypedEctoSchema
+
+    typed_schema "foo" do
+      has_many(:many, {"some_source", HasMany}, foreign_key: :table_id)
+    end
+
+    def get_types, do: Enum.reverse(@__typed_ecto_schema_types__)
+  end
+
+  test "we can use the source override support of Ecto when referring to schema's" do
+    types =
+      quote do
+        [
+          __meta__: unquote(Metadata).t(),
+          id: integer() | nil,
+          many: unquote(Ecto.Schema).has_many(unquote(HasMany).t())
+        ]
+      end
+
+    assert delete_context(types) == delete_context(RelationWithCustomSource.get_types())
+  end
+
   ##
   ## Helpers
   ##


### PR DESCRIPTION
This PR adds support for properly parsing "source" override types, e.g.:

```elixir
  defmodule MyModule do
     use TypedEctoSchema

     typed_schema "foo" do
       has_many :items, {"some_source", SomeSchema}
     end

   end
```