### PR TITLE
Expand unknown AST calls inside schema block before walking the AST

### DIFF
--- a/lib/typed_ecto_schema.ex
+++ b/lib/typed_ecto_schema.ex
@@ -193,7 +193,7 @@ defmodule TypedEctoSchema do
       unquote(prelude(opts))
 
       Ecto.Schema.embedded_schema do
-        unquote(inner(block))
+        unquote(inner(block, __CALLER__))
       end
 
       unquote(postlude(opts))
@@ -210,7 +210,7 @@ defmodule TypedEctoSchema do
       unquote(TypeBuilder).add_meta(__MODULE__)
 
       Ecto.Schema.schema unquote(table_name) do
-        unquote(inner(block))
+        unquote(inner(block, __CALLER__))
       end
 
       unquote(postlude(opts))
@@ -224,10 +224,10 @@ defmodule TypedEctoSchema do
     end
   end
 
-  defp inner(block) do
+  defp inner(block, env) do
     quote do
       unquote(TypeBuilder).add_primary_key(__MODULE__)
-      unquote(SyntaxSugar.apply_to_block(block))
+      unquote(SyntaxSugar.apply_to_block(block, env))
       unquote(TypeBuilder).enforce_keys()
     end
   end

--- a/lib/typed_ecto_schema/syntax_sugar.ex
+++ b/lib/typed_ecto_schema/syntax_sugar.ex
@@ -146,10 +146,16 @@ defmodule TypedEctoSchema.SyntaxSugar do
   defp transform_expression(unknown, env) do
     expanded = Macro.expand(unknown, env)
 
-    if expanded == unknown do
-      unknown
-    else
-      transform_expression(expanded, env)
+    case expanded do
+      ^unknown ->
+        unknown
+
+      {:__block__, block_context, calls} ->
+        new_calls = Enum.map(calls, &transform_expression(&1, env))
+        {:__block__, block_context, new_calls}
+
+      call ->
+        transform_expression(call, env)
     end
   end
 

--- a/lib/typed_ecto_schema/syntax_sugar.ex
+++ b/lib/typed_ecto_schema/syntax_sugar.ex
@@ -19,8 +19,8 @@ defmodule TypedEctoSchema.SyntaxSugar do
 
   @embeds_function_names [:embeds_one, :embeds_many]
 
-  @spec apply_to_block(Macro.t()) :: Macro.t()
-  def apply_to_block(block) do
+  @spec apply_to_block(Macro.t(), Macro.Env.t()) :: Macro.t()
+  def apply_to_block(block, env) do
     calls =
       case block do
         {:__block__, _, calls} ->
@@ -30,13 +30,13 @@ defmodule TypedEctoSchema.SyntaxSugar do
           [call]
       end
 
-    new_calls = Enum.map(calls, &transform_expression/1)
+    new_calls = Enum.map(calls, &transform_expression(&1, env))
 
     {:__block__, [], new_calls}
   end
 
-  @spec transform_expression(Macro.t()) :: Macro.t()
-  defp transform_expression({function_name, _, [name, type, opts]})
+  @spec transform_expression(Macro.t(), Macro.Env.t()) :: Macro.t()
+  defp transform_expression({function_name, _, [name, type, opts]}, _env)
        when function_name in @schema_function_names do
     ecto_opts = Keyword.drop(opts, [:__typed_ecto_type__, :enforce])
 
@@ -53,7 +53,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
     end
   end
 
-  defp transform_expression({function_name, _, [name, type]})
+  defp transform_expression({function_name, _, [name, type]}, _env)
        when function_name in @schema_function_names do
     quote do
       unquote(function_name)(unquote(name), unquote(type))
@@ -68,7 +68,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
     end
   end
 
-  defp transform_expression({:field, _, [name]}) do
+  defp transform_expression({:field, _, [name]}, _env) do
     quote do
       field(unquote(name))
 
@@ -82,7 +82,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
     end
   end
 
-  defp transform_expression({:timestamps, _, [opts]} = call) do
+  defp transform_expression({:timestamps, _, [opts]} = call, _env) do
     quote do
       unquote(call)
 
@@ -93,7 +93,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
     end
   end
 
-  defp transform_expression({function_name, _, [name, schema, opts, [do: block]]})
+  defp transform_expression({function_name, _, [name, schema, opts, [do: block]]}, _env)
        when function_name in @embeds_function_names do
     quote do
       {schema, opts} =
@@ -116,29 +116,42 @@ defmodule TypedEctoSchema.SyntaxSugar do
     end
   end
 
-  defp transform_expression({:timestamps, ctx, []}) do
-    transform_expression({:timestamps, ctx, [[]]})
+  defp transform_expression({:timestamps, ctx, []}, env) do
+    transform_expression({:timestamps, ctx, [[]]}, env)
   end
 
-  defp transform_expression({:::, _, [{function_name, _, [name, ecto_type, opts]}, type]})
+  defp transform_expression({:"::", _, [{function_name, _, [name, ecto_type, opts]}, type]}, env)
        when function_name in @schema_function_names do
     transform_expression(
-      {function_name, [], [name, ecto_type, [{:__typed_ecto_type__, Macro.escape(type)} | opts]]}
+      {function_name, [], [name, ecto_type, [{:__typed_ecto_type__, Macro.escape(type)} | opts]]},
+      env
     )
   end
 
-  defp transform_expression({:::, _, [{function_name, _, [name, ecto_type]}, type]})
+  defp transform_expression({:"::", _, [{function_name, _, [name, ecto_type]}, type]}, env)
        when function_name in @schema_function_names do
     transform_expression(
-      {function_name, [], [name, ecto_type, [__typed_ecto_type__: Macro.escape(type)]]}
+      {function_name, [], [name, ecto_type, [__typed_ecto_type__: Macro.escape(type)]]},
+      env
     )
   end
 
-  defp transform_expression({:::, _, [{:field, _, [name]}, type]}) do
-    transform_expression({:field, [], [name, :string, [__typed_ecto_type__: Macro.escape(type)]]})
+  defp transform_expression({:"::", _, [{:field, _, [name]}, type]}, env) do
+    transform_expression(
+      {:field, [], [name, :string, [__typed_ecto_type__: Macro.escape(type)]]},
+      env
+    )
   end
 
-  defp transform_expression(other), do: other
+  defp transform_expression(unknown, env) do
+    expanded = Macro.expand(unknown, env)
+
+    if expanded == unknown do
+      unknown
+    else
+      transform_expression(expanded, env)
+    end
+  end
 
   @doc false
   def __embeds_module__(env, name, opts, block) do

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule TypedEctoSchema.MixProject do
       app: :typed_ecto_schema,
       version: "0.3.0",
       elixir: "~> 1.7",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
@@ -21,6 +22,9 @@ defmodule TypedEctoSchema.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/test/support/support.ex
+++ b/test/support/support.ex
@@ -1,0 +1,7 @@
+defmodule TypedEctoSchema.TestMacros do
+  defmacro add_field(name, type) do
+    quote do
+      field(unquote(name), unquote(type))
+    end
+  end
+end

--- a/test/support/support.ex
+++ b/test/support/support.ex
@@ -1,9 +1,16 @@
 defmodule TypedEctoSchema.TestMacros do
   @moduledoc false
 
-  defmacro add_field(name, type) do
+  defmacro add_single_field(name, type) do
     quote do
       field(unquote(name), unquote(type))
+    end
+  end
+
+  defmacro add_two_fields(name0, type0, name1, type1) do
+    quote do
+      field(unquote(name0), unquote(type0))
+      field(unquote(name1), unquote(type1))
     end
   end
 end

--- a/test/support/support.ex
+++ b/test/support/support.ex
@@ -1,4 +1,6 @@
 defmodule TypedEctoSchema.TestMacros do
+  @moduledoc false
+
   defmacro add_field(name, type) do
     quote do
       field(unquote(name), unquote(type))

--- a/test/typed_ecto_schema_test.exs
+++ b/test/typed_ecto_schema_test.exs
@@ -624,8 +624,9 @@ defmodule TypedEctoSchemaTest do
 
     @primary_key false
     typed_schema "foo" do
-      add_field(:foo, :integer)
-      TypedEctoSchema.TestMacros.add_field(:bar, :float)
+      add_single_field(:foo, :integer)
+      TypedEctoSchema.TestMacros.add_single_field(:bar, :float)
+      TypedEctoSchema.TestMacros.add_two_fields(:f0, :boolean, :f1, :string)
       field(:baz, :boolean)
     end
 
@@ -637,6 +638,8 @@ defmodule TypedEctoSchemaTest do
              _,
              foo: {:|, [], [{:integer, [], []}, nil]},
              bar: {:|, [], [{:float, [], []}, nil]},
+             f0: {:|, [], [{:boolean, [], []}, nil]},
+             f1: {:|, [], [{{:., [], [String, :t]}, [], []}, nil]},
              baz: {:|, [], [{:boolean, [], []}, nil]}
            ] = delete_context(WithMacrosInsideBlock.get_types())
   end

--- a/test/typed_ecto_schema_test.exs
+++ b/test/typed_ecto_schema_test.exs
@@ -617,6 +617,30 @@ defmodule TypedEctoSchemaTest do
              delete_context(embed_types)
   end
 
+  defmodule WithMacrosInsideBlock do
+    use TypedEctoSchema
+
+    import TypedEctoSchema.TestMacros
+
+    @primary_key false
+    typed_schema "foo" do
+      add_field(:foo, :integer)
+      TypedEctoSchema.TestMacros.add_field(:bar, :float)
+      field(:baz, :boolean)
+    end
+
+    def get_types, do: Enum.reverse(@__typed_ecto_schema_types__)
+  end
+
+  test "we can use macros inside the block" do
+    assert [
+             _,
+             foo: {:|, [], [{:integer, [], []}, nil]},
+             bar: {:|, [], [{:float, [], []}, nil]},
+             baz: {:|, [], [{:boolean, [], []}, nil]}
+           ] = delete_context(WithMacrosInsideBlock.get_types())
+  end
+
   ##
   ## Helpers
   ##


### PR DESCRIPTION
This PR adds support for modules that call a macro that eventually produces an AST that we known (e.g., an ecto `field` call). This is an example of such a module:

```elixir
  defmodule MySchema do
     use TypedEctoSchema

     import MyMacros

     typed_schema "foo" do
       MyMacros.add_field(:foo, :integer)
     end
   end
```

