### PR TITLE
Various improvements

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/typed_ecto_schema.ex
+++ b/lib/typed_ecto_schema.ex
@@ -193,7 +193,7 @@ defmodule TypedEctoSchema do
       unquote(prelude(opts))
 
       Ecto.Schema.embedded_schema do
-        unquote(inner(block))
+        unquote(inner(block, __CALLER__))
       end
 
       unquote(postlude(opts))
@@ -210,7 +210,7 @@ defmodule TypedEctoSchema do
       unquote(TypeBuilder).add_meta(__MODULE__)
 
       Ecto.Schema.schema unquote(table_name) do
-        unquote(inner(block))
+        unquote(inner(block, __CALLER__))
       end
 
       unquote(postlude(opts))
@@ -224,10 +224,10 @@ defmodule TypedEctoSchema do
     end
   end
 
-  defp inner(block) do
+  defp inner(block, env) do
     quote do
       unquote(TypeBuilder).add_primary_key(__MODULE__)
-      unquote(SyntaxSugar.apply_to_block(block))
+      unquote(SyntaxSugar.apply_to_block(block, env))
       unquote(TypeBuilder).enforce_keys()
     end
   end

--- a/lib/typed_ecto_schema/ecto_type_mapper.ex
+++ b/lib/typed_ecto_schema/ecto_type_mapper.ex
@@ -46,8 +46,8 @@ defmodule TypedEctoSchema.EctoTypeMapper do
     |> add_nil_if_nullable(field_is_nullable?(nullable_default, function_name, opts))
   end
 
-  # Gets the base type for a given Ecto.Type.t()
-  @spec base_type_for(Ecto.Type.t(), field_options()) :: Macro.t()
+  # Gets the base type for a given Ecto.Type.t() or an AST representing a referenced type
+  @spec base_type_for(Ecto.Type.t() | Macro.t(), field_options()) :: Macro.t()
   defp base_type_for(atom, _opts) when atom in @module_for_ecto_type_keys do
     quote do
       unquote(Map.get(@module_for_ecto_type, atom)).t()
@@ -84,22 +84,15 @@ defmodule TypedEctoSchema.EctoTypeMapper do
     end
   end
 
-  defp base_type_for(atom, opts) when is_atom(atom) do
-    case to_string(atom) do
-      "Elixir.Ecto.Enum" ->
-        opts
-        |> Keyword.get(:values, [])
-        |> disjunction_typespec()
+  defp base_type_for({:__aliases__, _, [:Ecto, :Enum]}, opts) do
+    opts
+    |> Keyword.get(:values, [])
+    |> disjunction_typespec()
+  end
 
-      "Elixir." <> _ ->
-        quote do
-          unquote(atom).t()
-        end
-
-      _ ->
-        quote do
-          any()
-        end
+  defp base_type_for({:__aliases__, _, _} = ast, _opts) do
+    quote do
+      unquote(ast).t()
     end
   end
 

--- a/lib/typed_ecto_schema/ecto_type_mapper.ex
+++ b/lib/typed_ecto_schema/ecto_type_mapper.ex
@@ -47,7 +47,12 @@ defmodule TypedEctoSchema.EctoTypeMapper do
   end
 
   # Gets the base type for a given Ecto.Type.t() or an AST representing a referenced type
-  @spec base_type_for(Ecto.Type.t() | Macro.t(), field_options()) :: Macro.t()
+  @spec base_type_for(Ecto.Type.t() | {String.t(), Ecto.Type.t()} | Macro.t(), field_options()) ::
+          Macro.t()
+  defp base_type_for({source, actual_type}, opts) when is_binary(source) do
+    base_type_for(actual_type, opts)
+  end
+
   defp base_type_for(atom, _opts) when atom in @module_for_ecto_type_keys do
     quote do
       unquote(Map.get(@module_for_ecto_type, atom)).t()

--- a/lib/typed_ecto_schema/ecto_type_mapper.ex
+++ b/lib/typed_ecto_schema/ecto_type_mapper.ex
@@ -101,6 +101,25 @@ defmodule TypedEctoSchema.EctoTypeMapper do
     end
   end
 
+  defp base_type_for(atom, opts) when is_atom(atom) do
+    case to_string(atom) do
+      "Elixir.Ecto.Enum" ->
+        opts
+        |> Keyword.get(:values, [])
+        |> disjunction_typespec()
+
+      "Elixir." <> _ ->
+        quote do
+          unquote(atom).t()
+        end
+
+      _ ->
+        quote do
+          any()
+        end
+    end
+  end
+
   defp base_type_for(_, _opts) do
     quote do
       any()

--- a/lib/typed_ecto_schema/syntax_sugar.ex
+++ b/lib/typed_ecto_schema/syntax_sugar.ex
@@ -99,7 +99,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
       {schema, opts} =
         unquote(SyntaxSugar).__embeds_module__(
           __ENV__,
-          unquote(Macro.escape(schema)),
+          unquote(schema),
           unquote(opts),
           unquote(Macro.escape(block))
         )
@@ -154,7 +154,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
   end
 
   @doc false
-  def __embeds_module__(env, {:__aliases__, _, module_parts}, opts, block) do
+  def __embeds_module__(env, name, opts, block) do
     {pk, opts} = Keyword.pop(opts, :primary_key, {:id, :binary_id, autogenerate: true})
 
     block =
@@ -167,10 +167,8 @@ defmodule TypedEctoSchema.SyntaxSugar do
         end
       end
 
-    module = Module.concat(Module.split(env.module) ++ module_parts)
+    module = Module.concat(env.module, name)
     Module.create(module, block, env)
-
-    concatenated_module_parts = Module.split(module) |> Enum.map(&String.to_atom/1)
-    {{:__aliases__, [], concatenated_module_parts}, opts}
+    {module, opts}
   end
 end

--- a/lib/typed_ecto_schema/syntax_sugar.ex
+++ b/lib/typed_ecto_schema/syntax_sugar.ex
@@ -146,10 +146,16 @@ defmodule TypedEctoSchema.SyntaxSugar do
   defp transform_expression(unknown, env) do
     expanded = Macro.expand(unknown, env)
 
-    if expanded == unknown do
-      unknown
-    else
-      transform_expression(expanded, env)
+    case expanded do
+      ^unknown ->
+        unknown
+
+      {:__block__, block_context, calls} ->
+        new_calls = Enum.map(calls, &transform_expression(&1, env))
+        {:__block__, block_context, new_calls}
+
+      call ->
+        transform_expression(call, env)
     end
   end
 

--- a/lib/typed_ecto_schema/syntax_sugar.ex
+++ b/lib/typed_ecto_schema/syntax_sugar.ex
@@ -47,7 +47,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
         __MODULE__,
         unquote(function_name),
         unquote(name),
-        unquote(type),
+        unquote(Macro.escape(type)),
         unquote(opts)
       )
     end
@@ -62,7 +62,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
         __MODULE__,
         unquote(function_name),
         unquote(name),
-        unquote(type),
+        unquote(Macro.escape(type)),
         []
       )
     end
@@ -99,7 +99,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
       {schema, opts} =
         unquote(SyntaxSugar).__embeds_module__(
           __ENV__,
-          unquote(schema),
+          unquote(Macro.escape(schema)),
           unquote(opts),
           unquote(Macro.escape(block))
         )
@@ -120,28 +120,28 @@ defmodule TypedEctoSchema.SyntaxSugar do
     transform_expression({:timestamps, ctx, [[]]})
   end
 
-  defp transform_expression({:::, _, [{function_name, _, [name, ecto_type, opts]}, type]})
+  defp transform_expression({:"::", _, [{function_name, _, [name, ecto_type, opts]}, type]})
        when function_name in @schema_function_names do
     transform_expression(
       {function_name, [], [name, ecto_type, [{:__typed_ecto_type__, Macro.escape(type)} | opts]]}
     )
   end
 
-  defp transform_expression({:::, _, [{function_name, _, [name, ecto_type]}, type]})
+  defp transform_expression({:"::", _, [{function_name, _, [name, ecto_type]}, type]})
        when function_name in @schema_function_names do
     transform_expression(
       {function_name, [], [name, ecto_type, [__typed_ecto_type__: Macro.escape(type)]]}
     )
   end
 
-  defp transform_expression({:::, _, [{:field, _, [name]}, type]}) do
+  defp transform_expression({:"::", _, [{:field, _, [name]}, type]}) do
     transform_expression({:field, [], [name, :string, [__typed_ecto_type__: Macro.escape(type)]]})
   end
 
   defp transform_expression(other), do: other
 
   @doc false
-  def __embeds_module__(env, name, opts, block) do
+  def __embeds_module__(env, {:__aliases__, _, module_parts}, opts, block) do
     {pk, opts} = Keyword.pop(opts, :primary_key, {:id, :binary_id, autogenerate: true})
 
     block =
@@ -154,8 +154,10 @@ defmodule TypedEctoSchema.SyntaxSugar do
         end
       end
 
-    module = Module.concat(env.module, name)
+    module = Module.concat(Module.split(env.module) ++ module_parts)
     Module.create(module, block, env)
-    {module, opts}
+
+    concatenated_module_parts = Module.split(module) |> Enum.map(&String.to_atom/1)
+    {{:__aliases__, [], concatenated_module_parts}, opts}
   end
 end

--- a/lib/typed_ecto_schema/syntax_sugar.ex
+++ b/lib/typed_ecto_schema/syntax_sugar.ex
@@ -99,7 +99,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
       {schema, opts} =
         unquote(SyntaxSugar).__embeds_module__(
           __ENV__,
-          unquote(schema),
+          unquote(Macro.escape(schema)),
           unquote(opts),
           unquote(Macro.escape(block))
         )
@@ -160,7 +160,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
   end
 
   @doc false
-  def __embeds_module__(env, name, opts, block) do
+  def __embeds_module__(env, {:__aliases__, _, name}, opts, block) do
     {pk, opts} = Keyword.pop(opts, :primary_key, {:id, :binary_id, autogenerate: true})
 
     block =
@@ -173,7 +173,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
         end
       end
 
-    module = Module.concat(env.module, name)
+    module = Module.concat(env.module,  Module.concat(name))
     Module.create(module, block, env)
     {module, opts}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule TypedEctoSchema.MixProject do
       app: :typed_ecto_schema,
       version: "0.3.0",
       elixir: "~> 1.7",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
@@ -21,6 +22,9 @@ defmodule TypedEctoSchema.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/test/support/support.ex
+++ b/test/support/support.ex
@@ -1,0 +1,7 @@
+defmodule TypedEctoSchema.TestMacros do
+  defmacro add_field(name, type) do
+    quote do
+      field(unquote(name), unquote(type))
+    end
+  end
+end

--- a/test/support/support.ex
+++ b/test/support/support.ex
@@ -1,9 +1,16 @@
 defmodule TypedEctoSchema.TestMacros do
   @moduledoc false
 
-  defmacro add_field(name, type) do
+  defmacro add_single_field(name, type) do
     quote do
       field(unquote(name), unquote(type))
+    end
+  end
+
+  defmacro add_two_fields(name0, type0, name1, type1) do
+    quote do
+      field(unquote(name0), unquote(type0))
+      field(unquote(name1), unquote(type1))
     end
   end
 end

--- a/test/support/support.ex
+++ b/test/support/support.ex
@@ -1,4 +1,6 @@
 defmodule TypedEctoSchema.TestMacros do
+  @moduledoc false
+
   defmacro add_field(name, type) do
     quote do
       field(unquote(name), unquote(type))

--- a/test/typed_ecto_schema_test.exs
+++ b/test/typed_ecto_schema_test.exs
@@ -647,8 +647,9 @@ defmodule TypedEctoSchemaTest do
 
     @primary_key false
     typed_schema "foo" do
-      add_field(:foo, :integer)
-      TypedEctoSchema.TestMacros.add_field(:bar, :float)
+      add_single_field(:foo, :integer)
+      TypedEctoSchema.TestMacros.add_single_field(:bar, :float)
+      TypedEctoSchema.TestMacros.add_two_fields(:f0, :boolean, :f1, :string)
       field(:baz, :boolean)
     end
 
@@ -660,6 +661,8 @@ defmodule TypedEctoSchemaTest do
              _,
              foo: {:|, [], [{:integer, [], []}, nil]},
              bar: {:|, [], [{:float, [], []}, nil]},
+             f0: {:|, [], [{:boolean, [], []}, nil]},
+             f1: {:|, [], [{{:., [], [String, :t]}, [], []}, nil]},
              baz: {:|, [], [{:boolean, [], []}, nil]}
            ] = delete_context(WithMacrosInsideBlock.get_types())
   end

--- a/test/typed_ecto_schema_test.exs
+++ b/test/typed_ecto_schema_test.exs
@@ -633,11 +633,35 @@ defmodule TypedEctoSchemaTest do
         [
           __meta__: unquote(Metadata).t(),
           id: integer() | nil,
-          many: unquote(Ecto.Schema).has_many(unquote(HasMany).t())
+          many: unquote(Ecto.Schema).has_many(HasMany.t())
         ]
       end
 
     assert delete_context(types) == delete_context(RelationWithCustomSource.get_types())
+  end
+
+  defmodule WithMacrosInsideBlock do
+    use TypedEctoSchema
+
+    import TypedEctoSchema.TestMacros
+
+    @primary_key false
+    typed_schema "foo" do
+      add_field(:foo, :integer)
+      TypedEctoSchema.TestMacros.add_field(:bar, :float)
+      field(:baz, :boolean)
+    end
+
+    def get_types, do: Enum.reverse(@__typed_ecto_schema_types__)
+  end
+
+  test "we can use macros inside the block" do
+    assert [
+             _,
+             foo: {:|, [], [{:integer, [], []}, nil]},
+             bar: {:|, [], [{:float, [], []}, nil]},
+             baz: {:|, [], [{:boolean, [], []}, nil]}
+           ] = delete_context(WithMacrosInsideBlock.get_types())
   end
 
   ##

--- a/test/typed_ecto_schema_test.exs
+++ b/test/typed_ecto_schema_test.exs
@@ -617,6 +617,29 @@ defmodule TypedEctoSchemaTest do
              delete_context(embed_types)
   end
 
+  defmodule RelationWithCustomSource do
+    use TypedEctoSchema
+
+    typed_schema "foo" do
+      has_many(:many, {"some_source", HasMany}, foreign_key: :table_id)
+    end
+
+    def get_types, do: Enum.reverse(@__typed_ecto_schema_types__)
+  end
+
+  test "we can use the source override support of Ecto when referring to schema's" do
+    types =
+      quote do
+        [
+          __meta__: unquote(Metadata).t(),
+          id: integer() | nil,
+          many: unquote(Ecto.Schema).has_many(unquote(HasMany).t())
+        ]
+      end
+
+    assert delete_context(types) == delete_context(RelationWithCustomSource.get_types())
+  end
+
   ##
   ## Helpers
   ##

--- a/test/typed_ecto_schema_test.exs
+++ b/test/typed_ecto_schema_test.exs
@@ -260,11 +260,11 @@ defmodule TypedEctoSchemaTest do
                 enum_type_required: :foo1 | :foo2 | :foo3,
                 embed: Embedded.t() | nil,
                 embeds: list(Embedded.t()),
-                has_one: unquote(Ecto.Schema).has_one(unquote(HasOne).t()) | nil,
-                has_many: unquote(Ecto.Schema).has_many(unquote(HasMany).t()),
-                belongs_to: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
+                has_one: unquote(Ecto.Schema).has_one(HasOne.t()) | nil,
+                has_many: unquote(Ecto.Schema).has_many(HasMany.t()),
+                belongs_to: unquote(Ecto.Schema).belongs_to(BelongsTo.t()) | nil,
                 belongs_to_id: integer() | nil,
-                many_to_many: unquote(Ecto.Schema).many_to_many(unquote(ManyToMany).t()),
+                many_to_many: unquote(Ecto.Schema).many_to_many(ManyToMany.t()),
                 inserted_at: unquote(NaiveDateTime).t() | nil,
                 updated_at: unquote(NaiveDateTime).t() | nil
               }
@@ -324,13 +324,13 @@ defmodule TypedEctoSchemaTest do
           enum_type2: (:foo1 | :foo2) | nil,
           enum_type3: (:foo1 | :foo2 | :foo3) | nil,
           enum_type_required: :foo1 | :foo2 | :foo3,
-          embed: unquote(Embedded).t() | nil,
-          embeds: list(unquote(Embedded).t()),
-          has_one: unquote(Ecto.Schema).has_one(unquote(HasOne).t()) | nil,
-          has_many: unquote(Ecto.Schema).has_many(unquote(HasMany).t()),
-          belongs_to: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
+          embed: Embedded.t() | nil,
+          embeds: list(Embedded.t()),
+          has_one: unquote(Ecto.Schema).has_one(HasOne.t()) | nil,
+          has_many: unquote(Ecto.Schema).has_many(HasMany.t()),
+          belongs_to: unquote(Ecto.Schema).belongs_to(BelongsTo.t()) | nil,
           belongs_to_id: integer() | nil,
-          many_to_many: unquote(Ecto.Schema).many_to_many(unquote(ManyToMany).t()),
+          many_to_many: unquote(Ecto.Schema).many_to_many(ManyToMany.t()),
           inserted_at: unquote(NaiveDateTime).t() | nil,
           updated_at: unquote(NaiveDateTime).t() | nil
         ]
@@ -349,8 +349,8 @@ defmodule TypedEctoSchemaTest do
           normal: integer(),
           enforced: integer(),
           overriden: integer() | nil,
-          has_one: unquote(Ecto.Schema).has_one(unquote(HasOne).t()) | nil,
-          belongs_to: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
+          has_one: unquote(Ecto.Schema).has_one(HasOne.t()) | nil,
+          belongs_to: unquote(Ecto.Schema).belongs_to(BelongsTo.t()) | nil,
           belongs_to_id: integer()
         ]
       end
@@ -365,11 +365,11 @@ defmodule TypedEctoSchemaTest do
         [
           __meta__: unquote(Metadata).t(),
           id: binary() | nil,
-          normal: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
+          normal: unquote(Ecto.Schema).belongs_to(BelongsTo.t()) | nil,
           normal_id: binary() | nil,
-          custom_type: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
+          custom_type: unquote(Ecto.Schema).belongs_to(BelongsTo.t()) | nil,
           custom_type_id: integer() | nil,
-          no_define: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil
+          no_define: unquote(Ecto.Schema).belongs_to(BelongsTo.t()) | nil
         ]
       end
 
@@ -382,13 +382,13 @@ defmodule TypedEctoSchemaTest do
       quote do
         [
           __meta__: unquote(Metadata).t(),
-          normal: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
+          normal: unquote(Ecto.Schema).belongs_to(BelongsTo.t()) | nil,
           normal_id: integer() | nil,
-          with_custom_fk: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
+          with_custom_fk: unquote(Ecto.Schema).belongs_to(BelongsTo.t()) | nil,
           custom_fk: integer() | nil,
-          custom_type: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil,
+          custom_type: unquote(Ecto.Schema).belongs_to(BelongsTo.t()) | nil,
           custom_type_id: binary() | nil,
-          no_define: unquote(Ecto.Schema).belongs_to(unquote(BelongsTo).t()) | nil
+          no_define: unquote(Ecto.Schema).belongs_to(BelongsTo.t()) | nil
         ]
       end
 
@@ -523,7 +523,7 @@ defmodule TypedEctoSchemaTest do
   test "we can use inline embeds_one" do
     types =
       quote do
-        [one: unquote(InlineEmbedsOne.One).t() | nil]
+        [one: TypedEctoSchemaTest.InlineEmbedsOne.One.t() | nil]
       end
 
     assert delete_context(InlineEmbedsOne.get_types()) ==
@@ -579,7 +579,7 @@ defmodule TypedEctoSchemaTest do
   test "we can use inline embeds_many" do
     types =
       quote do
-        [many: list(unquote(InlineEmbedsMany.Many).t())]
+        [many: list(TypedEctoSchemaTest.InlineEmbedsMany.Many.t())]
       end
 
     assert delete_context(InlineEmbedsMany.get_types()) ==
@@ -590,7 +590,7 @@ defmodule TypedEctoSchemaTest do
         [id: binary() | nil, int: non_neg_integer() | nil]
       end
 
-    assert delete_context(InlineEmbedsMany.Many.get_types()) ==
+    assert delete_context(TypedEctoSchemaTest.InlineEmbedsMany.Many.get_types()) ==
              delete_context(embed_types)
   end
 

--- a/test/typed_ecto_schema_test.exs
+++ b/test/typed_ecto_schema_test.exs
@@ -523,7 +523,7 @@ defmodule TypedEctoSchemaTest do
   test "we can use inline embeds_one" do
     types =
       quote do
-        [one: TypedEctoSchemaTest.InlineEmbedsOne.One.t() | nil]
+        [one: unquote(InlineEmbedsOne.One).t() | nil]
       end
 
     assert delete_context(InlineEmbedsOne.get_types()) ==
@@ -579,7 +579,7 @@ defmodule TypedEctoSchemaTest do
   test "we can use inline embeds_many" do
     types =
       quote do
-        [many: list(TypedEctoSchemaTest.InlineEmbedsMany.Many.t())]
+        [many: list(unquote(InlineEmbedsMany.Many).t())]
       end
 
     assert delete_context(InlineEmbedsMany.get_types()) ==
@@ -590,7 +590,7 @@ defmodule TypedEctoSchemaTest do
         [id: binary() | nil, int: non_neg_integer() | nil]
       end
 
-    assert delete_context(TypedEctoSchemaTest.InlineEmbedsMany.Many.get_types()) ==
+    assert delete_context(InlineEmbedsMany.Many.get_types()) ==
              delete_context(embed_types)
   end
 
@@ -662,6 +662,12 @@ defmodule TypedEctoSchemaTest do
              bar: {:|, [], [{:float, [], []}, nil]},
              baz: {:|, [], [{:boolean, [], []}, nil]}
            ] = delete_context(WithMacrosInsideBlock.get_types())
+  end
+
+  test "syntactic sugar for embedded fields is correct" do
+    assert %Ecto.Changeset{} =
+             Ecto.Changeset.change(%InlineEmbedsOne{})
+             |> Ecto.Changeset.put_embed(:one, %{int: 123})
   end
 
   ##


### PR DESCRIPTION
This PR contains #15, #16, and #17.

Updates:

- Support for modules that call a macro that eventually produces an AST that we known (e.g., an ecto `field` call). This is an example of such a module:

```elixir
  defmodule MySchema do
     use TypedEctoSchema

     import MyMacros

     typed_schema "foo" do
       MyMacros.add_field(:foo, :integer)
     end
   end
```

- Support for properly parsing "source" override types, e.g.:

```elixir
  defmodule MyModule do
     use TypedEctoSchema

     typed_schema "foo" do
       has_many :items, {"some_source", SomeSchema}
     end

   end
```

- Avoids introducing unnecessary compile-time dependencies