### PR TITLE
release: prepare for 0.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,8 @@ jobs:
       matrix:
         elixir-version:
           - 1.11.4
-          - 1.12.2
+          - 1.12.3
+          - 1.13.3
         otp-version:
           - 22.3
           - 23.3

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ end
 Install it, add to your deps:
 
 ```elixir
-{:typed_ecto_schema, "~> 0.3.0"}
+{:typed_ecto_schema, "~> 0.4.0"}
 ```
 
 And change your `use Ecto.Schema` for `use TypedEctoSchema` and change the calls to `schema` for

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule TypedEctoSchema.MixProject do
   def project do
     [
       app: :typed_ecto_schema,
-      version: "0.3.0",
-      elixir: "~> 1.7",
+      version: "0.4.0",
+      elixir: "~> 1.9",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
I did a few things here:
- Added elixir 1.13.3 to the test matrix
- Changed the elixir minimum version to be the minimum we are currently testing in CI (1.9) on `mix.exs`
- Changed the README to include reference for `0.4.0` version
