### PR TITLE
feat: TypeCheck integration

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -36,6 +36,7 @@ defmodule TypedEctoSchema.MixProject do
 
       # Project dependencies
       {:ecto, "~> 3.5"},
+      {:type_check, "~> 0.12", optional: true},
 
       # Documentation dependencies
       {:ex_doc, "~> 0.28", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -23,5 +23,6 @@
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "telemetry": {:hex, :telemetry, "1.1.0", "a589817034a27eab11144ad24d5c0f9fab1f58173274b1e9bae7074af9cbee51", [:rebar3], [], "hexpm", "b727b2a1f75614774cff2d7565b64d0dfa5bd52ba517f16543e6fc7efcc0df48"},
+  "type_check": {:hex, :type_check, "0.12.1", "793e68dfafef2ecb1d94ed6c1ab25687b251f56ffa13bd2015ab0cda958930d4", [:mix], [{:credo, "~> 1.5", [hex: :credo, repo: "hexpm", optional: true]}, {:stream_data, "~> 0.5.0", [hex: :stream_data, repo: "hexpm", optional: true]}], "hexpm", "196a1b625833c6f69e13e62691c07b21358d2e5a4744e84f778f2db786205b48"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
closes #33

I decided to not even include an option as I feel options are a workaround for good experience.

My solution instead was to automatically check whether TypeCheck.Macros are required and just call it directly.
If you think it is too risky, we can add an option to enable that just as an "experimental feature" and we can warn people that this will change in the future (the feature will be enabled by default). What do you think?