### PR TITLE
Support enums which are stored as integers

### DIFF
--- a/lib/typed_ecto_schema/ecto_type_mapper.ex
+++ b/lib/typed_ecto_schema/ecto_type_mapper.ex
@@ -149,8 +149,20 @@ defmodule TypedEctoSchema.EctoTypeMapper do
     end
   end
 
+  defp disjunction_typespec([{atom, int}]) when is_atom(atom) and is_integer(int) do
+    quote do
+      unquote(atom)
+    end
+  end
+
+  defp disjunction_typespec([{atom, int} | tail]) when is_atom(atom) and is_integer(int) do
+    quote do
+      unquote(atom) | unquote(disjunction_typespec(tail))
+    end
+  end
+
   # Fallback for `Ecto.Enum` with ill-defined `:values`
-  defp disjunction_typespec(_) do
+  defp disjunction_typespec(_any) do
     quote do
       any()
     end

--- a/test/typed_ecto_schema_test.exs
+++ b/test/typed_ecto_schema_test.exs
@@ -59,6 +59,7 @@ defmodule TypedEctoSchemaTest do
         field(:enum_type1, Ecto.Enum, values: [:foo1])
         field(:enum_type2, Ecto.Enum, values: [:foo1, :foo2])
         field(:enum_type3, Ecto.Enum, values: [:foo1, :foo2, :foo3])
+        field(:enum_type_with_ints, Ecto.Enum, values: [foo1: 0, foo2: 1, foo3: 2])
         field(:enum_type_required, Ecto.Enum, values: [:foo1, :foo2, :foo3], null: false)
         embeds_one(:embed, Embedded)
         embeds_many(:embeds, Embedded)
@@ -178,6 +179,7 @@ defmodule TypedEctoSchemaTest do
              :enum_type1,
              :enum_type2,
              :enum_type3,
+             :enum_type_with_ints,
              :enum_type_required,
              :embed,
              :embeds,
@@ -253,6 +255,7 @@ defmodule TypedEctoSchemaTest do
           field(:enum_type1, Ecto.Enum, values: [:foo1])
           field(:enum_type2, Ecto.Enum, values: [:foo1, :foo2])
           field(:enum_type3, Ecto.Enum, values: [:foo1, :foo2, :foo3])
+          field(:enum_type_with_ints, Ecto.Enum, values: [foo1: 0, foo2: 1, foo3: 2])
           field(:enum_type_required, Ecto.Enum, values: [:foo1, :foo2, :foo3], null: false)
           embeds_one(:embed, Embedded)
           embeds_many(:embeds, Embedded)
@@ -275,6 +278,7 @@ defmodule TypedEctoSchemaTest do
                 enum_type1: :foo1 | nil,
                 enum_type2: (:foo1 | :foo2) | nil,
                 enum_type3: (:foo1 | :foo2 | :foo3) | nil,
+                enum_type_with_ints: (:foo1 | :foo2 | :foo3) | nil,
                 enum_type_required: :foo1 | :foo2 | :foo3,
                 embed: Embedded.t() | nil,
                 embeds: list(Embedded.t()),
@@ -341,6 +345,7 @@ defmodule TypedEctoSchemaTest do
           enum_type1: :foo1 | nil,
           enum_type2: (:foo1 | :foo2) | nil,
           enum_type3: (:foo1 | :foo2 | :foo3) | nil,
+          enum_type_with_ints: (:foo1 | :foo2 | :foo3) | nil,
           enum_type_required: :foo1 | :foo2 | :foo3,
           embed: Embedded.t() | nil,
           embeds: list(Embedded.t()),


### PR DESCRIPTION
Before this change a field like: 
```elixir
field(:enum_type_with_ints, Ecto.Enum, values: [foo1: 0, foo2: 1, foo3: 2])
```
 would result in the typespec `any() | nil`.

Now it will produce `(:foo1 | :foo2 | :foo3) | nil`