### PR TITLE
use Module.get_attribute since Ecto no longer declares module attribute directly

### DIFF
--- a/lib/typed_ecto_schema/syntax_sugar.ex
+++ b/lib/typed_ecto_schema/syntax_sugar.ex
@@ -93,7 +93,7 @@ defmodule TypedEctoSchema.SyntaxSugar do
 
       unquote(TypeBuilder).add_timestamps(
         __MODULE__,
-        Keyword.merge(@timestamps_opts, unquote(opts))
+        Keyword.merge(Module.get_attribute(__MODULE__, :timestamps_opts, []), unquote(opts))
       )
     end
   end


### PR DESCRIPTION
After upgrading our Ecto version to 3.13.0, we were encountering an error:

```
warning: undefined module attribute @timestamps_opts, please remove access to @timestamps_opts or explicitly set it before access
    │
 35 │   typed_schema "my_schema" do
    │   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/my_schema.ex:35: MySchema (module)

== Compilation error in file lib/my_schema.ex ==
** (FunctionClauseError) no function clause matching in Keyword.merge/2    
    
    The following arguments were given to Keyword.merge/2:
    
        # 1
        nil
    
        # 2
        [type: :utc_datetime_usec]
    
    Attempted function clauses (showing 3 out of 3):
    
        def merge(keywords1, []) when is_list(keywords1)
        def merge([], keywords2) when is_list(keywords2)
        def merge(keywords1, keywords2) when is_list(keywords1) and is_list(keywords2)
```

It looks like Ecto changed the `@timestamps_opts` from being defined explicitly to using:
```
    # Those module attributes are accessed only dynamically
    # so we explicitly reference them here to avoid warnings.
    Module.get_attribute(module, :timestamps_opts)
```