### PR TITLE
Fix @timestamps_opts nil issue for Ecto 3.13 compatibility

### DIFF
--- a/lib/typed_ecto_schema/syntax_sugar.ex
+++ b/lib/typed_ecto_schema/syntax_sugar.ex
@@ -91,9 +91,12 @@ defmodule TypedEctoSchema.SyntaxSugar do
     quote do
       unquote(call)
 
+      # Handle case where @timestamps_opts might be nil in newer Ecto versions
+      timestamps_opts = Module.get_attribute(__MODULE__, :timestamps_opts) || []
+
       unquote(TypeBuilder).add_timestamps(
         __MODULE__,
-        Keyword.merge(@timestamps_opts, unquote(opts))
+        Keyword.merge(timestamps_opts, unquote(opts))
       )
     end
   end


### PR DESCRIPTION
## Fix for Ecto 3.13 Compatibility

This PR fixes a compatibility issue with Ecto 3.13 where `@timestamps_opts` module attribute is no longer guaranteed to be defined.

### The Problem

When using `typed_schema` with `timestamps()` in Ecto 3.13, the following error occurs:

```
** (FunctionClauseError) no function clause matching in Keyword.merge/2
    The following arguments were given to Keyword.merge/2:
        # 1
        nil
        # 2
        []
```

This happens because the library assumes `@timestamps_opts` will always be defined in the module, but Ecto 3.13 doesn't set this attribute by default.

### The Solution

The fix checks if `@timestamps_opts` is defined before attempting to merge it:

```elixir
# Handle case where @timestamps_opts might be nil in newer Ecto versions
timestamps_opts = Module.get_attribute(__MODULE__, :timestamps_opts) || []

unquote(TypeBuilder).add_timestamps(
  __MODULE__,
  Keyword.merge(timestamps_opts, unquote(opts))
)
```

### Testing

This fix has been tested with:
- Ecto 3.13.1
- Elixir 1.18.4
- Successfully compiles schemas that previously failed with the `@timestamps_opts` error

### Backwards Compatibility

This change is backwards compatible - if `@timestamps_opts` is defined (as in older Ecto versions), it will use that value. If not defined, it defaults to an empty list.